### PR TITLE
updated Banner content-type for handling images with type

### DIFF
--- a/src/api/banner/content-types/banner/schema.json
+++ b/src/api/banner/content-types/banner/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "banners",
+  "info": {
+    "singularName": "banner",
+    "pluralName": "banners",
+    "displayName": "Banners"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "videos"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/api/banner/controllers/banner.js
+++ b/src/api/banner/controllers/banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * banner controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::banner.banner');

--- a/src/api/banner/routes/banner.js
+++ b/src/api/banner/routes/banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * banner router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::banner.banner');

--- a/src/api/banner/services/banner.js
+++ b/src/api/banner/services/banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * banner service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::banner.banner');


### PR DESCRIPTION
### Change in This PR:
-  Added Banner Conntent-type.

To add images in strapi with title and type (home, property, default and so on...) and get those images with their type and title as well.